### PR TITLE
Fix ready status after Stripe payment

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,8 @@
             <stripe-buy-button
             buy-button-id="buy_btn_1RlvbECOWsHWoBEGK3O2YxKI"
             publishable-key="pk_test_51Rb21ICOWsHWoBEGgfvfQyHIMU7kFYHbvX6zMV0uLwihH959xhgD3HYVzSbfHr6mI2pD4Nlt8kPS2dHxFZW3PQw900LJ7rQz9w"
+            client-reference-id="{{ user_id }}"
+            redirect-url="{{ url_for('payment_complete') }}"
             >
             </stripe-buy-button>
             {% if user_is_registered %}


### PR DESCRIPTION
## Summary
- keep session `is_ready` in sync with database
- show registration status on homepage
- prevent losing access after paying
- redirect players to the game page once payment completes

## Testing
- `python -m py_compile app.py utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687a641a91888325955be0a6693a6815