### PR TITLE
Handle Stripe return via session ID

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,3 +7,4 @@ class Config:
     DATABASE = 'data.db'
     STRIPE_PUBLISHABLE_KEY = 'pk_live_51Rb21ICOWsHWoBEGmAY8BEDjuDe7KjsHoTY4hzhve9aiZd0tUaQoaIEG3aoGHHnwjtc8VrEBDJrIZReI0CTVLYqQ00fikEjr67'
     STRIPE_BUY_BUTTON_ID = 'buy_btn_1RlodyCOWsHWoBEGAMGyrBcx'
+    STRIPE_SECRET_KEY = os.environ.get('STRIPE_SECRET_KEY', 'sk_test_12345')

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,15 +25,15 @@
             <stripe-buy-button
             buy-button-id="buy_btn_1RlvbECOWsHWoBEGK3O2YxKI"
             publishable-key="pk_test_51Rb21ICOWsHWoBEGgfvfQyHIMU7kFYHbvX6zMV0uLwihH959xhgD3HYVzSbfHr6mI2pD4Nlt8kPS2dHxFZW3PQw900LJ7rQz9w"
+            client-reference-id="{{ user_id }}"
+            redirect-url="{{ url_for('payment_complete', _external=True) }}"
             >
             </stripe-buy-button>
             {% if user_is_registered %}
                 <p>Tu es déjà inscrit à la compétition.</p>
                 <a href="/game"><button>Accéder au jeu</button></a>
             {% else %}
-                <form action="/register" method="post">
-                    <button type="submit" style="background:#28a745;color:white;">Participer</button>
-                </form>
+                <p>Clique sur le bouton Stripe pour payer et rejoindre la compétition.</p>
             {% endif %}
             {% if duel_opponent %}
                 <div>


### PR DESCRIPTION
## Summary
- add secret key config for Stripe API
- handle checkout.session return using session_id so payment works even if the login session was lost
- set the redirect URL in the Stripe button to the absolute payment_complete URL

## Testing
- `python -m py_compile app.py utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687a641a91888325955be0a6693a6815